### PR TITLE
Fixed issue that prevented building when installing from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "node server.js",
     "deploy": "NODE_ENV=production webpack -p --config webpack.production.js",
     "build": "babel -d lib/ src/",
+    "install": "npm run clean && npm run build",
     "clean": "rimraf lib",
     "prepublish": "npm run clean && npm run build"
   },


### PR DESCRIPTION
Closes #23 and closes #26 

Adds a script that builds the project after installing from npm (the package was broken previously)