### PR TITLE
Multiple UI fixes (color picker, absolute positioning, etc)

### DIFF
--- a/examples/App.module.css
+++ b/examples/App.module.css
@@ -1,9 +1,9 @@
 @import url(https://fonts.googleapis.com/css?family=Lora:400,400italic,700);
 
 .example {
+	display: flex;
+	flex-direction: column;
 	margin-bottom: 80px;
-	border-bottom: 1px solid black;
-	overflow: hidden;
 }
 
 .example h3 {
@@ -36,8 +36,6 @@
 
 .preview {
 	float: left;
-	margin-left: 50px;
-	margin-top: 20px;
 	margin-bottom: 110px;
 }
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "node server.js",
     "deploy": "NODE_ENV=production webpack -p --config webpack.production.js",
     "build": "babel -d lib/ src/",
+    "install": "npm run clean && npm run build",
     "clean": "rimraf lib",
     "prepublish": "npm run clean && npm run build"
   },

--- a/src/Designer.js
+++ b/src/Designer.js
@@ -531,46 +531,48 @@ class Designer extends Component {
              style={{
                 ...styles.container,
                 ...this.props.style,
-                width: canvasWidth,
-                height: canvasHeight,
                 padding: 0
              }}
              onMouseMove={this.onDrag.bind(this)}
              onMouseUp={this.stopDrag.bind(this)}>
 
-          {isEditMode && ObjectEditor && (
-             <ObjectEditor object={currentObject}
-                 offset={this.getOffset()}
-                 onUpdate={(object) =>
-                    this.updateObject(selectedObjectIndex, object)}
-                 onClose={() => this.setState({mode: modes.FREE})}
-                 width={width}
-                 height={height} />)}
-
-          {showHandler && (
-            <Handler
-              boundingBox={handler}
-              canResize={_(currentObject).has('width') ||
-                         _(currentObject).has('height')}
-              canRotate={_(currentObject).has('rotate')}
-              onMouseLeave={this.hideHandler.bind(this)}
-              onDoubleClick={this.showEditor.bind(this)}
-              onDrag={this.startDrag.bind(this, modes.DRAG)}
-              onResize={this.startDrag.bind(this, modes.SCALE)}
-              onRotate={this.startDrag.bind(this, modes.ROTATE)} /> )}
-
+          {/* Left Panel: Displays insertion tools (shapes, images, etc.) */}
           {InsertMenuComponent && (
             <InsertMenuComponent tools={objectTypes}
               currentTool={selectedTool}
               onSelect={this.selectTool.bind(this)} />
           )}
 
-          {this.renderSVG()}
+          {/* Center Panel: Displays the preview */}
+          <div style={styles.canvasContainer}>
+            {isEditMode && ObjectEditor && (
+               <ObjectEditor object={currentObject}
+                   offset={this.getOffset()}
+                   onUpdate={(object) =>
+                      this.updateObject(selectedObjectIndex, object)}
+                   onClose={() => this.setState({mode: modes.FREE})}
+                   width={width}
+                   height={height} />)}
 
+            {showHandler && (
+              <Handler
+                boundingBox={handler}
+                canResize={_(currentObject).has('width') ||
+                           _(currentObject).has('height')}
+                canRotate={_(currentObject).has('rotate')}
+                onMouseLeave={this.hideHandler.bind(this)}
+                onDoubleClick={this.showEditor.bind(this)}
+                onDrag={this.startDrag.bind(this, modes.DRAG)}
+                onResize={this.startDrag.bind(this, modes.SCALE)}
+                onRotate={this.startDrag.bind(this, modes.ROTATE)} /> )}
+
+            {this.renderSVG()}
+          </div>
+
+          {/* Right Panel: Displays text, styling and sizing tools */}
           {showPropertyPanel && (
             <PanelList
               id={this.props.id}
-              offset={this.getOffset()}
               object={objectWithInitial}
               onArrange={this.handleArrange.bind(this)}
               onChange={this.handleObjectChange.bind(this)}
@@ -584,6 +586,11 @@ class Designer extends Component {
 
 export const styles = {
   container: {
+    position: 'relative',
+    display: 'flex',
+    flexDirection: 'row'
+  },
+  canvasContainer: {
     position: 'relative'
   },
   keyboardManager: {

--- a/src/panels/ColorInput.js
+++ b/src/panels/ColorInput.js
@@ -1,5 +1,5 @@
 import React, {Component} from 'react';
-import ColorPicker from 'react-color';
+import { SketchPicker } from 'react-color';
 import _ from 'lodash';
 import Icon from '../Icon';
 
@@ -7,19 +7,12 @@ import styles from './styles';
 
 class ColorInput extends Component {
   state = {
-    show: false,
-    x: 0,
-    y: 0
+    show: false
   };
 
-  toggleVisibility(event) {
+  toggleVisibility = (event) => {
     if (event.preventDefault) {
       event.preventDefault();
-      let rect = event.target.getBoundingClientRect();
-      this.setState({
-        x: rect.left,
-        y: rect.top
-      });
     }
 
     let {show} = this.state;
@@ -28,35 +21,39 @@ class ColorInput extends Component {
     })
   }
 
-  handleChange(color) {
+  handleChange = (color) => {
     let {r, g, b, a} = color.rgb;
     this.props.onChange(`rgba(${r}, ${g}, ${b}, ${a})`);
   }
 
-  render() {
-    let {show, x, y} = this.state;
-    let {value} = this.props;
+  handleClose = (event) => {
+    if (event.preventDefault) {
+      event.preventDefault();
+    }
 
-    let position = {
-      position: "fixed",
-      left: x + 3,
-      top: y - 2
-    };
+    this.setState({
+      show: false
+    })
+  }
+
+  render() {
+    let {show} = this.state;
+    let {value} = this.props;
 
     return (
       <div>
-        <ColorPicker
-          color={value}
-          display={show}
-          positionCSS={position}
-          onChange={this.handleChange.bind(this)}
-          onClose={this.toggleVisibility.bind(this)}
-          type="chrome" />
         <a href="#"
          style={styles.colorInput}
          onClick={this.toggleVisibility.bind(this)}>
           <span style={{...styles.color, backgroundColor: value}} />
          </a>
+         {show && <div style={styles.colorPopover}>
+           <div style={styles.colorCover} onClick={this.handleClose} />
+           <SketchPicker
+             color={value}
+             onChange={this.handleChange}
+             />
+         </div>}
       </div>
     );
   }

--- a/src/panels/InsertMenu.js
+++ b/src/panels/InsertMenu.js
@@ -71,9 +71,6 @@ class InsertMenu extends Component {
 
 const styles = {
   insertMenu: {
-    position: 'absolute',
-    marginTop: 0,
-    marginLeft: -40,
     height: 40,
     width: 40,
     overflow: 'hidden',

--- a/src/panels/PanelList.js
+++ b/src/panels/PanelList.js
@@ -13,19 +13,12 @@ import Column from './Column';
 
 class PanelList extends Component {
   render() {
-    let {object, offset, objectComponent, id} = this.props;
-    let style = {
-      left: offset.width + offset.x,
-      top: offset.y + window.scrollY,
-    };
-
+    let {object, objectComponent, id} = this.props;
 
     return (
-      <Portal className="propertyPanel" closeOnEsc closeOnOutsideClick isOpened={true}>
-        <div style={{...styles.propertyPanel, ...style}}>
-          {objectComponent.panels.map((Panel, i) => <Panel key={i} id={id} {...this.props} />)}
-        </div>
-      </Portal>
+      <div style={{...styles.propertyPanel}}>
+        {objectComponent.panels.map((Panel, i) => <Panel key={i} id={id} {...this.props} />)}
+      </div>
     );
   }
 };

--- a/src/panels/styles.js
+++ b/src/panels/styles.js
@@ -1,9 +1,7 @@
 export default {
   propertyPanel: {
-    position: "absolute",
+    position: 'relative',
     width: 200,
-    top: 0,
-    left: 0,
     padding: '0 5px 6px 5px',
     fontFamily: '"Lucida Grande", sans-serif',
     fontSize: 11
@@ -85,6 +83,18 @@ export default {
     height: 14,
     display: 'inline-block',
     borderRadius: '50%'
+  },
+  colorCover: {
+    position: 'fixed',
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+  },
+  colorPopover: {
+    position: 'absolute',
+    marginTop: 8,
+    zIndex: 999999
   },
   empty: {
     display: 'none',


### PR DESCRIPTION
### Changes
- Fixed the color picker which broke after an upgrade of the dependency (used to be always open regardless of state)
- Switched from absolute positioning of the panels to relative positioning using a flex view (simple three-panel structure with a left menu, center canvas and right tools). Removes the need for complicated offset calculations and compensation with CSS padding.
- Switched color picker to `SketchPicker` which is more feature rich